### PR TITLE
fix some bug and export more fields

### DIFF
--- a/pkg/ace.go
+++ b/pkg/ace.go
@@ -253,6 +253,14 @@ func (s BasicAce) GetPrincipal() SID {
 	return s.SecurityIdentifier
 }
 
+func (s BasicAce) GetInheritedObjectType() string {
+	return ""
+}
+
+func (s BasicAce) GetObjectType() string {
+	return ""
+}
+
 //AdvancedAce represents an Object Ace
 type AdvancedAce struct {
 	Flags               ACEInheritanceFlags //4 bytes
@@ -264,6 +272,14 @@ type AdvancedAce struct {
 // GetPrincipal returns an ACEs Principal
 func (s AdvancedAce) GetPrincipal() SID {
 	return s.SecurityIdentifier
+}
+
+func (s AdvancedAce) GetInheritedObjectType() string {
+	return GuidParser(s.InheritedObjectType)
+}
+
+func (s AdvancedAce) GetObjectType() string {
+	return GuidParser(s.ObjectType)
 }
 
 // FlagsString returns an human-readable representation of an ACEHeader's Flags
@@ -282,4 +298,21 @@ func (s AdvancedAce) FlagsString() string {
 // go-winacl
 type ObjectAce interface {
 	GetPrincipal() SID
+	GetInheritedObjectType() string
+	GetObjectType() string
+}
+
+func GuidParser(guid GUID) string{
+	var uuid string
+	timeLow := fmt.Sprintf("%02x",guid.Data1)
+	timeMid := fmt.Sprintf("%02x",guid.Data2)
+	timeHighAndVersion := fmt.Sprintf("%02x",guid.Data3)
+	clockSeqHiAndReserved := fmt.Sprintf("%02x",guid.Data4[0])
+	clockSeqLow := fmt.Sprintf("%02x",guid.Data4[1])
+	node := fmt.Sprintf("%02x%02x%02x%02x%02x%02x",guid.Data4[2],guid.Data4[3],
+		guid.Data4[4],guid.Data4[5],guid.Data4[6],guid.Data4[7])
+
+	uuid = timeLow + "-" + timeMid + "-" + timeHighAndVersion + "-" +
+		clockSeqHiAndReserved + clockSeqLow + "-" + node
+	return "{" + uuid + "}"
 }

--- a/pkg/ace.go
+++ b/pkg/ace.go
@@ -314,9 +314,9 @@ type ObjectAce interface {
 
 func GuidParser(guid GUID) string{
 	var uuid string
-	timeLow := fmt.Sprintf("%02x",guid.Data1)
-	timeMid := fmt.Sprintf("%02x",guid.Data2)
-	timeHighAndVersion := fmt.Sprintf("%02x",guid.Data3)
+	timeLow := fmt.Sprintf("%08x",guid.Data1)
+	timeMid := fmt.Sprintf("%04x",guid.Data2)
+	timeHighAndVersion := fmt.Sprintf("%04x",guid.Data3)
 	clockSeqHiAndReserved := fmt.Sprintf("%02x",guid.Data4[0])
 	clockSeqLow := fmt.Sprintf("%02x",guid.Data4[1])
 	node := fmt.Sprintf("%02x%02x%02x%02x%02x%02x",guid.Data4[2],guid.Data4[3],

--- a/pkg/ace.go
+++ b/pkg/ace.go
@@ -261,6 +261,11 @@ func (s BasicAce) GetObjectType() string {
 	return ""
 }
 
+func (s BasicAce) GetInheritanceFlags() ACEInheritanceFlags{
+	var flag ACEInheritanceFlags
+	return flag
+}
+
 //AdvancedAce represents an Object Ace
 type AdvancedAce struct {
 	Flags               ACEInheritanceFlags //4 bytes
@@ -282,6 +287,10 @@ func (s AdvancedAce) GetObjectType() string {
 	return GuidParser(s.ObjectType)
 }
 
+func (s AdvancedAce) GetInheritanceFlags() ACEInheritanceFlags{
+	return s.Flags
+}
+
 // FlagsString returns an human-readable representation of an ACEHeader's Flags
 func (s AdvancedAce) FlagsString() string {
 	sb := strings.Builder{}
@@ -300,6 +309,7 @@ type ObjectAce interface {
 	GetPrincipal() SID
 	GetInheritedObjectType() string
 	GetObjectType() string
+	GetInheritanceFlags() ACEInheritanceFlags
 }
 
 func GuidParser(guid GUID) string{

--- a/pkg/ntsd.go
+++ b/pkg/ntsd.go
@@ -38,6 +38,11 @@ func NewNtSecurityDescriptor(ntsdBytes []byte) (NtSecurityDescriptor, error) {
 		return ntsd, err
 	}
 
+	ntsd.SACL, err = NewACL(buf)
+	if err != nil {
+		return ntsd, err
+	}
+
 	ntsd.DACL, err = NewACL(buf)
 	if err != nil {
 		return ntsd, err


### PR DESCRIPTION
I used ldap.v3 package to get NtSecurityDescriptor, found that go-winacl error parsing the NtSecurityDescriptor.
The error code fix in https://github.com/kgoins/go-winacl/pull/8/commits/472eac090445edd0213e92400e19640ad60f571c

the code is like that:
```golang
result,_ := scanner.Search("CN=Administrator,CN=Users,DC=test,DC=local","(name=*)",[]string{"nTSecurityDescriptor"})
sd := result.Entries[0].Attributes[0]
fmt.Println(result)
ntsd, _ := winacl.NewNtSecurityDescriptor(sd.ByteValues[0])

ace := ntsd.DACL.Aces[0].ObjectAce
fmt.Println(ace.GetInheritedObjectType())
fmt.Println(ace.GetObjectType())
fmt.Println(ace.GetPrincipal())
```